### PR TITLE
support using PyHKEY as a context manager

### DIFF
--- a/.docs/README_template.rst
+++ b/.docs/README_template.rst
@@ -2,7 +2,7 @@ fake_winreg
 ===========
 
 
-Version v1.5.6 as of 2020-10-09 see `Changelog`_
+Version v1.5.7 as of 2021-12-16 see `Changelog`_
 
 
 .. include:: ./badges.rst

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ planned:
     - investigate SYSWOW32/64 Views
     - Admin Permissions
 
+v1.5.7
+--------
+2021-12-16: feature release
+    - allow PyHKEY to act as a context manager
+
 v1.5.6
 --------
 2020-10-09: service release

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ fake_winreg
 ===========
 
 
-Version v1.5.6 as of 2020-10-09 see `Changelog`_
+Version v1.5.7 as of 2021-12-16 see `Changelog`_
 
 |travis_build| |license| |jupyter| |pypi|
 
@@ -2132,6 +2132,11 @@ planned:
     - auditing events
     - investigate SYSWOW32/64 Views
     - Admin Permissions
+
+v1.5.7
+--------
+2021-12-16: feature release
+    - allow PyHKEY to act as a context manager
 
 v1.5.6
 --------

--- a/fake_winreg/__init__conf__.py
+++ b/fake_winreg/__init__conf__.py
@@ -1,6 +1,6 @@
 name = 'fake_winreg'
 title = 'fake winreg, in order to test registry related functions on linux'
-version = 'v1.5.6'
+version = 'v1.5.7'
 url = 'https://github.com/bitranox/fake_winreg'
 author = 'Robert Nowotny'
 author_email = 'bitranox@gmail.com'
@@ -14,7 +14,7 @@ Info for fake_winreg:
 
     fake winreg, in order to test registry related functions on linux
 
-    Version : v1.5.6
+    Version : v1.5.7
     Url     : https://github.com/bitranox/fake_winreg
     Author  : Robert Nowotny
     Email   : bitranox@gmail.com""")

--- a/fake_winreg/fake_winreg.py
+++ b/fake_winreg/fake_winreg.py
@@ -85,6 +85,8 @@ class PyHKEY(HKEYType):
     To guarantee cleanup, you can call either the Close() method on the object, or the CloseKey() function.
     All registry functions in this module return one of these objects.
 
+    This wrapper can also be used as a context manager, to guarantee that the key will be closed after use.
+
     # Not implemented features of the Original Object - its not hard, but I did not need it ATM:
     All registry functions in this module which accept a handle object also accept an integer, however, use of the handle object is encouraged.
     Handle objects provide semantics for __bool__() – thus

--- a/fake_winreg/fake_winreg.py
+++ b/fake_winreg/fake_winreg.py
@@ -105,6 +105,12 @@ class PyHKEY(HKEYType):
     def __init__(self, handle: fake_reg.FakeRegistryKey, access: int = KEY_READ):
         super().__init__(handle, access)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.Close()
+
 
 # DataTypesHandle{{{
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if is_travis_deploy() and is_tagged_commit():
 
 setup_kwargs: Dict[str, Any] = dict()
 setup_kwargs["name"] = "fake_winreg"
-setup_kwargs["version"] = "v1.5.6"
+setup_kwargs["version"] = "v1.5.7"
 setup_kwargs["url"] = "https://github.com/bitranox/fake_winreg"
 setup_kwargs["packages"] = find_packages()
 setup_kwargs["package_data"] = {"fake_winreg": ["py.typed", "*.pyi", "__init__.pyi"]}

--- a/tests/test_default_values.py
+++ b/tests/test_default_values.py
@@ -10,17 +10,16 @@ winreg.load_fake_registry(fake_registry)
 def key_handle_test_read_only():
     reg_handle = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
     key_handle = winreg.CreateKey(reg_handle, 'Software\\lib_registry_test')
-    key_handle_read_only = winreg.OpenKeyEx(key_handle, '', 0, winreg.KEY_READ)
-    yield key_handle_read_only
-    # teardown code
-    try:
-        winreg.DeleteKey(key_handle, '')
-    # On Windows sometimes this Error occurs, if we try again to delete a key
-    # that is already marked for deletion
-    # OSError: [WinError 1018]
-    except OSError:
-        pass
-    winreg.CloseKey(key_handle)
+    with winreg.OpenKeyEx(key_handle, '', 0, winreg.KEY_READ) as key_handle_read_only:
+        yield key_handle_read_only
+        # teardown code
+        try:
+            winreg.DeleteKey(key_handle, '')
+        # On Windows sometimes this Error occurs, if we try again to delete a key
+        # that is already marked for deletion
+        # OSError: [WinError 1018]
+        except OSError:
+            pass
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
- [?] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this Pull Request introduce?** (Bug fix, feature, docs update, ...)

This is a new feature

* **What is the current behavior?** (You can also link to an open issue here)

Fixes #15

* **What is the new behavior (if this is a feature change)?**

PyHKEY now implements `__enter__()` and `__exit__()` methods so can be used as a context manager, just like in real winreg

* **Does this Pull Request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

This commit adds __enter__() and __exit__() functions to the PyHKEY class to
allow it to be used as a context manager, mimicking the standard winreg
library. The only thing this does is close the key at the end of the context
manager, which matches the implementation of actual winreg.

Testing is handled by modifying the key_handle_test_read_only() pytest fixture
to use the context manager.

